### PR TITLE
Chargement des paramètres d'affichage des nutriments dès la connexion

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -95,8 +95,9 @@ use Symfony\Component\Routing\Attribute\Route;
         return new JsonResponse(
             [
                 "userId" => $user->getId(),
-                "username" => $user->getFullName()]
-            );
+                "username" => $user->getFullName(),
+                "customization" => $user->getNutrientsDisplayPreference()
+            ]);
     }
 
     #[Route('/api/profile/verify/{username}', methods: Request::METHOD_GET)]

--- a/src/Repository/RecipeRepository.php
+++ b/src/Repository/RecipeRepository.php
@@ -95,7 +95,7 @@ class RecipeRepository extends ServiceEntityRepository
     public function findLatest()
     {
         $qb = $this->createQueryBuilder('r')
-            ->select('r.id', 'r.title', 's.name as subcategory', 'c.name as category')
+            ->select('r.id', 'r.title', 's.name as subcategory', 'c.name as category', 'r.pralIndex')
             ->leftJoin('r.subCategory', 's')
             ->leftJoin('r.category', 'c')
             ->orderBy('r.id', 'DESC')


### PR DESCRIPTION
Les paramètres d'affichage des nutriments sont retournés dès la connexion de l'utilisateur pour permettre un chargement immédiat.

L'indice pral des recettes récupéré en base de données lors de 'appel à la méthode findLatest() pour permettre de renvoyer l'indice pral directement au front lorsqu'on récupère les 3 dernières recettes postées par les membres.

